### PR TITLE
fix: Avoid throw in browsers without TouchEvent

### DIFF
--- a/src/picker/Alpha.vue
+++ b/src/picker/Alpha.vue
@@ -86,7 +86,7 @@ export default defineComponent({
         let clientY
         if (e instanceof MouseEvent) {
           clientY = e.clientY
-        } else if (e instanceof TouchEvent) {
+        } else if (window.TouchEvent && e instanceof TouchEvent) {
           clientY = e.touches[0].clientY
         }
 
@@ -114,7 +114,7 @@ export default defineComponent({
       }
 
       // 触摸事件
-      if (e instanceof TouchEvent) {
+      if (window.TouchEvent && e instanceof TouchEvent) {
         e.preventDefault() // 防止页面滚动
         document.addEventListener('touchmove', onSelectMoving, { passive: false })
         document.addEventListener('touchend', onSelectEnd)

--- a/src/picker/Hue.vue
+++ b/src/picker/Hue.vue
@@ -67,7 +67,7 @@ export default defineComponent({
         let clientY
         if (e instanceof MouseEvent) {
           clientY = e.clientY
-        } else if (e instanceof TouchEvent) {
+        } else if (window.TouchEvent && e instanceof TouchEvent) {
           clientY = e.touches[0].clientY
         }
 
@@ -97,7 +97,7 @@ export default defineComponent({
       }
 
       // 触摸事件
-      if (e instanceof TouchEvent) {
+      if (window.TouchEvent && e instanceof TouchEvent) {
         e.preventDefault() // 防止触摸滑动页面
         document.addEventListener('touchmove', onSelectMoving, { passive: false })
         document.addEventListener('touchend', onSelectEnd)

--- a/src/picker/Saturation.vue
+++ b/src/picker/Saturation.vue
@@ -60,7 +60,7 @@ export default defineComponent({
         if (e instanceof MouseEvent) {
           clientX = e.clientX
           clientY = e.clientY
-        } else if (e instanceof TouchEvent) {
+        } else if (window.TouchEvent && e instanceof TouchEvent) {
           clientX = e.touches[0].clientX
           clientY = e.touches[0].clientY
         }
@@ -98,7 +98,7 @@ export default defineComponent({
         document.addEventListener('mouseup', onSelectEnd)
       }
 
-      if (e instanceof TouchEvent) {
+      if (window.TouchEvent && e instanceof TouchEvent) {
         e.preventDefault() // 防止页面滑动
         document.addEventListener('touchmove', onSelectMoving, { passive: false })
         document.addEventListener('touchend', onSelectEnd)


### PR DESCRIPTION
On many desktop Ubuntu distributions, Firefox does not have TouchEvent support (since there is no way for the hardware to generate TouchEvent events). In such a case, vue-color-picker throws an error `TouchEvent is not defined` whenever someone clicks on the hue bar or the saturation/value square of the picker.

With this PR, vue-color-picker always checks if TouchEvent is available before using it, and thereby avoids the crash. The fix methodology follows https://stackoverflow.com/questions/27313488/touchevent-not-working-in-firefox-and-other-website-browser

One other note: in my setup in order for vue-color-picker to build and test successfully, I was obliged to execute `yarn add canvas` before the build. I did not include the corresponding changes to package.json and yarn.lock in this PR, because you may have an alternate build procedure that you intend for this package. I just wanted to make you aware that at least on my OpenSUSE Tumbleweed distribution, a straight git clone followed by `yarn install; yarn run build` does not succeed.